### PR TITLE
Include errors in the state of the form

### DIFF
--- a/src/altForm.js
+++ b/src/altForm.js
@@ -34,7 +34,7 @@ export default (namespace, alt, opts) => {
       this.setState({ errors: invalidState })
     },
     change(state) {
-      this.setState({ errors: null, state })
+      this.setState({ errors: null, ...state })
     },
     focus(key) {
       this.setState({
@@ -64,7 +64,7 @@ export default (namespace, alt, opts) => {
       }
     }, {
       ...opts,
-      state: { ...state, ...store.getState().state },
+      state: { ...state, ...store.getState() },
     })
   }
 


### PR DESCRIPTION
Previously errors were inaccessible when calling `MyForm.getProps()`. This is annoying for me because after dispatching errors to the form:

``` js
let { failed } = getActionCreators('Signin');
alt.dispatch(failed.dispatch(res.data.errors));
```

The errors are unavailable in `MyForm.getProps()`

This makes it so it is easy to access to errors in the form.
